### PR TITLE
bench: add oj

### DIFF
--- a/benchmark/run_benchmark.rb
+++ b/benchmark/run_benchmark.rb
@@ -3,6 +3,7 @@
 require 'benchmark/ips'
 require 'json'
 require 'simdjson'
+require 'oj'
 
 files = %w[
   apache_builds.json
@@ -17,6 +18,9 @@ files = files.to_h
 def run_report(rep, name, src)
   rep.report("#{name} - simdjson") do
     Simdjson.parse(src)
+  end
+  rep.report("#{name} - OJ") do
+    Oj.load(src)
   end
   rep.report("#{name} - standard JSON") do
     JSON.parse(src)

--- a/simdjson.gemspec
+++ b/simdjson.gemspec
@@ -32,4 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake-compiler'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'rubocop-performance'
+  spec.add_development_dependency 'oj'
 end


### PR DESCRIPTION
`Oj` has traditionally been the fastest parser, so it's a fair target. Added it locally since I thought it'd be a good comparison. Seems like `simdjson` is about 25-30% faster than `Oj`.