### PR TITLE
Add -Wno-register flag

### DIFF
--- a/ext/simdjson/extconf.rb
+++ b/ext/simdjson/extconf.rb
@@ -2,7 +2,7 @@ require 'mkmf'
 
 # rubocop:disable Style/GlobalVars
 
-$CXXFLAGS += ' -std=c++1z -mpclmul -mbmi -mbmi2 -mavx -mavx2 '
+$CXXFLAGS += ' -std=c++1z -mpclmul -mbmi -mbmi2 -mavx -mavx2 -Wno-register '
 
 CWD = __dir__
 SIMDJSON_DIR = File.join(CWD, '..', '..', 'vendor', 'simdjson')


### PR DESCRIPTION
While GC++ treats no-register as a warning, clang (v11 on MacOS)
considers it an error breaking the compilation. This flag prevents
that behaviour making clang to compile successfully.

P.S. FYI also made a branch for v0.3 on my fork but I don't think it's worth of a PR - I just made it compile but I am not confident enough on it