### PR TITLE
Fix performance on Ruby 3.0

### DIFF
--- a/ext/simdjson/extconf.rb
+++ b/ext/simdjson/extconf.rb
@@ -2,6 +2,6 @@
 
 require 'mkmf'
 
-$CXXFLAGS += ' -std=c++11 -Wno-register '
+$CXXFLAGS += ' $(optflags) $(debugflags) -std=c++1z -Wno-register '
 
 create_makefile('simdjson/simdjson')


### PR DESCRIPTION
The Makefile generated by extconf.rb has changed in Ruby 3.0.
Therefore, when using Ruby 3.0, the optimization flags are not set properly and it reduced the performance.

This patch will set optimization flags in compiling properly.

- Here is Ruby 2.7 Makefile result:

```
CXXFLAGS = $(CCDLFLAGS) -g -O2 -std=c++1z -Wno-register  $(ARCH_FLAG)
```

- Here is Ruby 3.0 Makefile result:

```
CXXFLAGS = $(CCDLFLAGS)  -std=c++1z -Wno-register  $(ARCH_FLAG)
```

This PR will fix issue same with https://github.com/anilmaurya/fast_jsonparser/issues/20