### PR TITLE
Fix parsed strings having ASCII-8BIT encoding instead of UTF-8

### DIFF
--- a/ext/simdjson/simdjson_ruby.cpp
+++ b/ext/simdjson/simdjson_ruby.cpp
@@ -27,7 +27,7 @@ static VALUE make_ruby_object(dom::element element) {
         VALUE hash = rb_hash_new();
         for (dom::key_value_pair field : dom::object(element)) {
             std::string_view view(field.key);
-            VALUE k = rb_str_new(view.data(), view.size());
+            VALUE k = rb_utf8_str_new(view.data(), view.size());
             VALUE v = make_ruby_object(field.value);
             rb_hash_aset(hash, k, v);
         }
@@ -40,7 +40,7 @@ static VALUE make_ruby_object(dom::element element) {
         return DBL2NUM(double(element));
     } else if (t == dom::element_type::STRING) {
         std::string_view view(element);
-        return rb_str_new(view.data(), view.size());
+        return rb_utf8_str_new(view.data(), view.size());
     } else if (t == dom::element_type::BOOL) {
         return bool(element) ? Qtrue : Qfalse;
     } else if (t == dom::element_type::NULL_VALUE) {

--- a/test/simdjson_test.rb
+++ b/test/simdjson_test.rb
@@ -54,6 +54,28 @@ class SimdjsonTest < Minitest::Test
     end
   end
 
+  def test_utf8_encoding
+    x = Simdjson.parse('{"key": "café"}')
+    assert_equal Encoding::UTF_8, x.keys.first.encoding
+    assert_equal Encoding::UTF_8, x['key'].encoding
+    assert x['key'].valid_encoding?
+  end
+
+  def test_utf8_encoding_issue_20
+    # Exact reproduction case from issue #20
+    y = Simdjson.parse('{"m":" \u2013 "}')
+    assert_equal Encoding::UTF_8, y['m'].encoding
+    assert y['m'].valid_encoding?
+  end
+
+  def test_utf8_encoding_in_array
+    ary = Simdjson.parse('["hello", "café"]')
+    ary.each do |str|
+      assert_equal Encoding::UTF_8, str.encoding
+      assert str.valid_encoding?
+    end
+  end
+
   def test_non_utf8_string
     [Encoding::UTF_16LE, Encoding::SJIS, Encoding::EUC_JP].each do |enc|
       src = 'あああ'.encode(enc)


### PR DESCRIPTION
## Summary
- Use `rb_utf8_str_new` instead of `rb_str_new` for both hash keys and string values in the C extension
- simdjson guarantees valid UTF-8 output, so tagging Ruby strings as UTF-8 is correct
- Aligns behavior with `JSON.parse` and `Oj.load` which both return UTF-8 strings

Fixes #20

## Test plan
- Encoding tests added for hash keys/values, arrays, and exact issue #20 reproduction case
- All 13 tests pass (25 assertions, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)